### PR TITLE
[BREAKING CHANGE]: fix signInWithProvider now returns a UserCredential

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -134,10 +134,10 @@ export function useFirebaseAuth() {
     }
 
     try {
-      const { user } = await firebase
+      const userCredential = await firebase
         .auth()
         .signInWithPopup(provider as firebaseNs.auth.AuthProvider)
-      return user
+      return userCredential
     } catch (e) {
       setState({
         error: e,


### PR DESCRIPTION
`signInWithProvider` now returns a `UserCredential` instead of regular firebase `User`

ref: #2 